### PR TITLE
Revert "Fix a situation where no tasks triggers loop() in main.cpp"

### DIFF
--- a/src/MicroTasks.cpp
+++ b/src/MicroTasks.cpp
@@ -126,7 +126,6 @@ void MicroTasksClass::wakeTask(Task *oTask, WakeReason eReason)
     DBUG(ulNext);
     DBUG(":");
     DBUGLN(oTask->ulNextLoop);
-    wakeLoop(false);
   }
 }
 


### PR DESCRIPTION
Reverts jeremypoulter/MicroTasks#3

This causing issue in an corner case where if a task is woken up in an ISR, then it shouldn't use wakeLoop(false) but the ISR equivalent. If task is woken up manually. Then it will be executed immediately, then at the end, it schedule a return other than infinite. In this case, wakeLoop(false) will cause stability issue.

Also, if a task is woken on schedule and exit with a scheduled wake in the future, then the loop will run twice before it goes to block state.